### PR TITLE
fixed wrong ant script name

### DIFF
--- a/build_war_dist.xml
+++ b/build_war_dist.xml
@@ -1,5 +1,5 @@
 <project xmlns:artifact="antlib:org.apache.maven.artifact.ant"
-         name="eHourStandaloneDist" default="archive" basedir=".">
+         name="eHourWarDist" default="archive" basedir=".">
     <description>
         Builds eHour WAR dist file (don't mention Maven's assembly plugin..)
         Before running this script eHour must be compiled with mvn clean install -Pprod -Pwar


### PR DESCRIPTION
I did this because IntelliJ Idea displays ant script by name and not by filename.
