### PR TITLE
PM report crash

### DIFF
--- a/eHour-common/src/main/java/net/rrm/ehour/report/reports/element/AssignmentAggregateReportElement.java
+++ b/eHour-common/src/main/java/net/rrm/ehour/report/reports/element/AssignmentAggregateReportElement.java
@@ -182,7 +182,7 @@ public class AssignmentAggregateReportElement
      */
     public Number getHours()
     {
-        return hours;
+        return hours == null ? 0 : hours;
     }
 
     /**


### PR DESCRIPTION
PM reporting a project w/out hours in the selected timeframe causes eHour to crash.

In many places getHour().floatValue() is called without null checking.
