### PR TITLE
[squid:S1118] Utility classes should not have public constructors

### DIFF
--- a/eHour-common/src/main/java/net/rrm/ehour/config/EhourConfigUtil.java
+++ b/eHour-common/src/main/java/net/rrm/ehour/config/EhourConfigUtil.java
@@ -6,6 +6,9 @@ import org.joda.time.DateTimeZone;
 import java.util.TimeZone;
 
 public class EhourConfigUtil {
+    private EhourConfigUtil() {
+    }
+
     public static TimeZone getTzAsTimeZone(EhourConfig config) {
         if (StringUtils.isNotBlank(config.getTimeZone())) {
             return DateTimeZone.forID(config.getTimeZone()).toTimeZone();

--- a/eHour-common/src/main/java/net/rrm/ehour/config/LocaleUtil.java
+++ b/eHour-common/src/main/java/net/rrm/ehour/config/LocaleUtil.java
@@ -8,6 +8,9 @@ public class LocaleUtil {
 
     public static final Locale DEFAULT_LOCALE = new Locale("nl", "NL");
 
+    private LocaleUtil() {
+    }
+
     public static Locale currencyForLanguageTag(String tag) {
         if (StringUtils.isBlank(tag)) {
             return DEFAULT_LOCALE;

--- a/eHour-common/src/main/java/net/rrm/ehour/report/reports/element/FlatReportElementBuilder.java
+++ b/eHour-common/src/main/java/net/rrm/ehour/report/reports/element/FlatReportElementBuilder.java
@@ -6,6 +6,9 @@ import net.rrm.ehour.domain.ProjectAssignment;
 import net.rrm.ehour.domain.User;
 
 public class FlatReportElementBuilder {
+    private FlatReportElementBuilder() {
+    }
+
     public static FlatReportElement buildFlatReportElement(ProjectAssignment assignment) {
         FlatReportElement element = new FlatReportElement();
 

--- a/eHour-common/src/main/java/net/rrm/ehour/util/DomainUtil.java
+++ b/eHour-common/src/main/java/net/rrm/ehour/util/DomainUtil.java
@@ -24,6 +24,9 @@ import java.util.Collection;
 import java.util.List;
 
 public class DomainUtil {
+    private DomainUtil() {
+    }
+
     /**
      * Get a list of primary keys of out a list of domain objects
      */

--- a/eHour-common/src/test/java/net/rrm/ehour/domain/ProjectAssignmentObjectMother.java
+++ b/eHour-common/src/test/java/net/rrm/ehour/domain/ProjectAssignmentObjectMother.java
@@ -10,6 +10,9 @@ import net.rrm.ehour.util.EhourConstants;
  */
 public class ProjectAssignmentObjectMother
 {
+	private ProjectAssignmentObjectMother() {
+	}
+
 	public static ProjectAssignment createProjectAssignment(User user, Project project)
 	{
 		ProjectAssignment assignment = new ProjectAssignment(user, project);

--- a/eHour-common/src/test/java/net/rrm/ehour/domain/ProjectObjectMother.java
+++ b/eHour-common/src/test/java/net/rrm/ehour/domain/ProjectObjectMother.java
@@ -10,6 +10,9 @@ import java.util.Set;
  * @author thies (www.te-con.nl)
  */
 public class ProjectObjectMother {
+    private ProjectObjectMother() {
+    }
+
     public static Set<Project> createProjects(int projectCount) {
         Set<Project> projects = Sets.newHashSet();
 

--- a/eHour-common/src/test/java/net/rrm/ehour/domain/TimesheetEntryObjectMother.java
+++ b/eHour-common/src/test/java/net/rrm/ehour/domain/TimesheetEntryObjectMother.java
@@ -8,6 +8,9 @@ import java.util.Date;
  * @author thies (www.te-con.nl)
  */
 public class TimesheetEntryObjectMother {
+    private TimesheetEntryObjectMother() {
+    }
+
     public static TimesheetEntry createTimesheetEntry(int prjId, Date date, float hours) {
         TimesheetEntryId id = new TimesheetEntryId();
         id.setEntryDate(date);

--- a/eHour-common/src/test/java/net/rrm/ehour/domain/UserDepartmentObjectMother.java
+++ b/eHour-common/src/test/java/net/rrm/ehour/domain/UserDepartmentObjectMother.java
@@ -8,6 +8,9 @@ import com.google.common.collect.Sets;
  * @author thies (www.te-con.nl)
  */
 public class UserDepartmentObjectMother {
+    private UserDepartmentObjectMother() {
+    }
+
     public static UserDepartment createUserDepartment() {
         return createUserDepartment(1);
     }

--- a/eHour-common/src/test/java/net/rrm/ehour/domain/UserObjectMother.java
+++ b/eHour-common/src/test/java/net/rrm/ehour/domain/UserObjectMother.java
@@ -11,6 +11,9 @@ import java.util.Set;
  * @author thies (www.te-con.nl)
  */
 public class UserObjectMother {
+    private UserObjectMother() {
+    }
+
     public static User createUser() {
         return createUser(new UserDepartment(1));
     }

--- a/eHour-persistence/src/main/java/net/rrm/ehour/persistence/hibernate/HibernateCache.java
+++ b/eHour-persistence/src/main/java/net/rrm/ehour/persistence/hibernate/HibernateCache.java
@@ -3,6 +3,9 @@ package net.rrm.ehour.persistence.hibernate;
 import org.hibernate.SessionFactory;
 
 public class HibernateCache {
+    private HibernateCache() {
+    }
+
     public static void clearHibernateCache(SessionFactory sf) {
         sf.getCache().evictAllRegions();
     }

--- a/eHour-selenium/src/test/java/net/rrm/ehour/it/DatabaseTruncater.java
+++ b/eHour-selenium/src/test/java/net/rrm/ehour/it/DatabaseTruncater.java
@@ -5,6 +5,9 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 public class DatabaseTruncater {
+    private DatabaseTruncater() {
+    }
+
     public static void truncate(DataSource dataSource) throws SQLException {
          Connection connection = dataSource.getConnection();
 

--- a/eHour-selenium/src/test/java/net/rrm/ehour/it/driver/CustomerManagementDriver.java
+++ b/eHour-selenium/src/test/java/net/rrm/ehour/it/driver/CustomerManagementDriver.java
@@ -12,6 +12,9 @@ public class CustomerManagementDriver {
     public static final ItCustomer ANOTHER_ACTIVE_CUSTOMER = new ItCustomer("VU", "VU");
     public static final ItCustomer INACTIVE_CUSTOMER = new ItCustomer("CED", "CED");
 
+    private CustomerManagementDriver() {
+    }
+
     public static void assertCustomerManagementLoaded() {
         assertEquals("Client management", Driver.getTitle());
     }

--- a/eHour-selenium/src/test/java/net/rrm/ehour/it/driver/EhourApplicationDriver.java
+++ b/eHour-selenium/src/test/java/net/rrm/ehour/it/driver/EhourApplicationDriver.java
@@ -10,6 +10,9 @@ import static net.rrm.ehour.it.driver.UserManagementDriver.*;
 import static org.junit.Assert.assertTrue;
 
 public class EhourApplicationDriver {
+    private EhourApplicationDriver() {
+    }
+
     public static void loginAdmin() {
         login(new ItUser("admin", "admin"));
     }

--- a/eHour-selenium/src/test/java/net/rrm/ehour/it/driver/TimesheetLockDriver.java
+++ b/eHour-selenium/src/test/java/net/rrm/ehour/it/driver/TimesheetLockDriver.java
@@ -10,6 +10,9 @@ import static net.rrm.ehour.it.driver.ItUtil.*;
 import static org.junit.Assert.assertEquals;
 
 public class TimesheetLockDriver {
+    private TimesheetLockDriver() {
+    }
+
     public static void navigateToAdminLocks() {
         Driver.get(BASE_URL + "/eh/op/lock");
     }

--- a/eHour-service/src/main/java/net/rrm/ehour/backup/domain/ParserUtil.java
+++ b/eHour-service/src/main/java/net/rrm/ehour/backup/domain/ParserUtil.java
@@ -9,6 +9,9 @@ import javax.xml.stream.events.XMLEvent;
  *         Created on: 11/28/10 - 1:06 AM
  */
 public class ParserUtil {
+    private ParserUtil() {
+    }
+
     public static String parseNextEventAsCharacters(XMLEventReader eventReader) throws XMLStreamException {
         // no chars can only mean an end importer
         StringBuilder data = new StringBuilder();

--- a/eHour-service/src/main/java/net/rrm/ehour/report/reports/util/ReportUtil.java
+++ b/eHour-service/src/main/java/net/rrm/ehour/report/reports/util/ReportUtil.java
@@ -12,6 +12,9 @@ import net.rrm.ehour.report.reports.element.AssignmentAggregateReportElement;
  */
 public class ReportUtil
 {
+	private ReportUtil() {
+	}
+
 	/**
 	 * Check if aggregate list is empty
 	 * @param aggregates

--- a/eHour-service/src/test/java/net/rrm/ehour/report/reports/element/AssignmentAggregateReportElementMother.java
+++ b/eHour-service/src/test/java/net/rrm/ehour/report/reports/element/AssignmentAggregateReportElementMother.java
@@ -8,6 +8,9 @@ import net.rrm.ehour.domain.ProjectAssignmentObjectMother;
  * @author thies (www.te-con.nl)
  */
 public class AssignmentAggregateReportElementMother {
+    private AssignmentAggregateReportElementMother() {
+    }
+
     public static AssignmentAggregateReportElement createProjectAssignmentAggregate() {
         return createProjectAssignmentAggregate(1, 1, 1);
     }

--- a/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/component/CommonModifiers.java
+++ b/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/component/CommonModifiers.java
@@ -23,6 +23,9 @@ import org.apache.wicket.AttributeModifier;
  */
 
 public class CommonModifiers {
+    private CommonModifiers() {
+    }
+
     /**
      * Tabindex modifier
      *

--- a/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/form/FormUtil.java
+++ b/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/form/FormUtil.java
@@ -38,6 +38,9 @@ import java.util.List;
  */
 @SuppressWarnings("serial")
 public class FormUtil {
+    private FormUtil() {
+    }
+
     public static void setSubmitActions(final FormConfig formConfig) {
         final boolean inDemoMode = formConfig.getConfig().isInDemoMode();
 

--- a/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/report/PoiUtil.java
+++ b/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/report/PoiUtil.java
@@ -21,6 +21,9 @@ import org.apache.poi.ss.usermodel.Workbook;
 
 public class PoiUtil
 {
+	private PoiUtil() {
+	}
+
 	public static int getImageType(String type)
 	{
 		if (type.equalsIgnoreCase("png"))

--- a/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/util/HtmlUtil.java
+++ b/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/util/HtmlUtil.java
@@ -27,7 +27,10 @@ public class HtmlUtil
 {
 	public static final String HTML_NBSP = "&nbsp;";
 
-    /**
+	private HtmlUtil() {
+	}
+
+	/**
 	 * Get a &ampnbsp;label
 	 */
 	public static Label getNbspLabel(String id)

--- a/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/util/WebUtils.java
+++ b/eHour-wicketweb/src/main/java/net/rrm/ehour/ui/common/util/WebUtils.java
@@ -31,6 +31,9 @@ import java.util.Locale;
  */
 
 public class WebUtils {
+    private WebUtils() {
+    }
+
     public static String formatDate(String format, Date date) {
         Locale locale = EhourWebSession.getEhourConfig().getFormattingLocale();
 

--- a/eHour-wicketweb/src/test/java/net/rrm/ehour/ui/DummyUIDataGenerator.java
+++ b/eHour-wicketweb/src/test/java/net/rrm/ehour/ui/DummyUIDataGenerator.java
@@ -9,6 +9,9 @@ import java.util.List;
 
 public class DummyUIDataGenerator {
 
+    private DummyUIDataGenerator() {
+    }
+
     public static List<ProjectAssignmentType> getProjectAssignmentTypes() {
         List<ProjectAssignmentType> list = new ArrayList<ProjectAssignmentType>();
 

--- a/eHour-wicketweb/src/test/java/net/rrm/ehour/ui/report/detailed/DetailedReportDataObjectMother.java
+++ b/eHour-wicketweb/src/test/java/net/rrm/ehour/ui/report/detailed/DetailedReportDataObjectMother.java
@@ -28,6 +28,9 @@ import java.util.List;
 
 @SuppressWarnings({"deprecation"})
 public class DetailedReportDataObjectMother {
+    private DetailedReportDataObjectMother() {
+    }
+
     public static List<FlatReportElement> getFlatReportElements() {
         List<FlatReportElement> els = new ArrayList<FlatReportElement>();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.